### PR TITLE
Silence verbose console.log outputs.

### DIFF
--- a/lib/FastXlsxReader.js
+++ b/lib/FastXlsxReader.js
@@ -123,7 +123,7 @@ class FastXlsxReader {
       backwards
     } = this.options;
 
-    console.log("Reading Excel file...", input);
+    // console.log("Reading Excel file...", input);
 
     const eventNames = [...DEFAULT_EVENTS];
     if (typeof onCell === "function") eventNames.push("cell");
@@ -170,7 +170,7 @@ class FastXlsxReader {
       useMemoryForItems // useful when no onRecord handler and no output provided
     } = this.options;
 
-    console.log("Creating Excel file reader...", input);
+    // console.log("Creating Excel file reader...", input);
 
     const eventNames = [...DEFAULT_EVENTS];
     if (typeof onCell === "function") eventNames.push("cell");
@@ -261,7 +261,7 @@ class FastXlsxReader {
           const name = headerPrefix + i;
           this._header.push(lowerCase ? name.toLowerCase() : name);
         }
-        console.log("Created arbitrary header: ", this._header);
+        // console.log("Created arbitrary header: ", this._header);
       }
     } else {
       this._header = FastXlsxReader._normalizeHeader(row, !schema && lowerCase);


### PR DESCRIPTION
Script shouldn't pollute the log without good reason. Spams "Creating Excel file reader..." when doing module require()
Consider enabling console.log output behind options flag.